### PR TITLE
FIX: Adjust CSS to support "Powered by Discourse" link

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -5,6 +5,11 @@
   grid-column-gap: #{$sidebar_gap}px;
   grid-template-areas:
     "sidebar leftsidebar content rightsidebar";
+  &:has(.powered-by-discourse) {
+    grid-template-areas:
+      "sidebar leftsidebar content rightsidebar"
+      "sidebar leftsidebar below-content rightsidebar";
+  }
   grid-template-columns: 0 auto minmax(0, 1fr) auto;
 
   &.has-sidebar {
@@ -33,6 +38,11 @@
 body.has-sidebar-page #main-outlet-wrapper {
   grid-template-areas:
     "leftsidebar sidebar content rightsidebar";
+  &:has(.powered-by-discourse) {
+    grid-template-areas:
+      "leftsidebar sidebar content rightsidebar"
+      "leftsidebar sidebar below-content rightsidebar";
+  }
   grid-template-columns: auto var(--d-sidebar-width) minmax(0, 1fr) auto;
   grid-column-gap: #{$sidebar_gap}px;
 }
@@ -41,6 +51,11 @@ body.has-sidebar-page #main-outlet-wrapper {
   display: grid;
   grid-template-areas:
     "content rightaltsidebar";
+  &:has(.powered-by-discourse) {
+    grid-template-areas:
+      "content rightaltsidebar"
+      "below-content rightaltsidebar";
+  }
   grid-template-columns: minmax(0, 1fr) auto;
   grid-column-gap: #{$rightalt_sidebar_gap}px;
 }


### PR DESCRIPTION
This fixes the CSS for the "_Powered by Discourse_” link when the `enable powered by discourse` setting is enabled. ([PR](https://github.com/discourse/discourse/commit/9376a2e755dd3c1c384b5ce752f471f9d00a79ee))

Core added a new `below-content` grid area to `#main-outlet-wrapper`.
This PR adjusts the CSS to include it.

(Note: I could not test with `.full-width`, it's unclear how you use it, especially when the above rule will have priority)

---

Before:
![image](https://github.com/merefield/discourse-tc-bars/assets/360640/e1d9f305-75c6-464a-8650-c0abb4f396b0)

After:
![image](https://github.com/merefield/discourse-tc-bars/assets/360640/f96f87f7-2bd1-4e48-be9d-173fdabcb8f2)

--- 

More screenshots with CSS are displayed.
<details>
<summary>With Sidebar:</summary>

![image](https://github.com/merefield/discourse-tc-bars/assets/360640/4125af5c-5cf1-4fec-ac7c-eea974ada50d)
</details>
<details>
<summary>Without Sidebar:</summary>

![image](https://github.com/merefield/discourse-tc-bars/assets/360640/e356649f-eac3-4794-98a3-d8a9f3e9302d)
</details>

--- 

With the setting is disabled:

<details>
<summary>With Sidebar:</summary>

![image](https://github.com/merefield/discourse-tc-bars/assets/360640/29c93664-1e23-4f55-a560-ca1ed0022713)
</details>
<details>
<summary>Without Sidebar:</summary>

![image](https://github.com/merefield/discourse-tc-bars/assets/360640/e20581c1-6b7e-4712-9d0b-dde1e58ec15a)
</details>

Let me know if I forgot to test a situation!



